### PR TITLE
Align feature class naming to a new scheme.

### DIFF
--- a/src/blockquote.js
+++ b/src/blockquote.js
@@ -8,18 +8,14 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import BlockQuoteEngine from './blockquoteengine';
-import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
-
-import quoteIcon from '@ckeditor/ckeditor5-core/theme/icons/quote.svg';
-import '../theme/blockquote.css';
+import BlockQuoteEditing from './blockquoteediting';
+import BlockQuoteUI from './blockquoteui';
 
 /**
  * The block quote plugin.
  *
- * It introduces the `'blockQuote'` button and requires the {@link module:block-quote/blockquoteengine~BlockQuoteEngine}
- * plugin. It also changes <kbd>Enter</kbd> key behavior so it escapes block quotes when pressed in an
- * empty quoted block.
+ * It loads the {@link module:block-quote/blockquoteediting~BlockQuoteEditing block quote editing feature}
+ * and {@link module:block-quote/blockquoteui~BlockQuoteUI block quote UI feature}.
  *
  * @extends module:core/plugin~Plugin
  */
@@ -28,7 +24,7 @@ export default class BlockQuote extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ BlockQuoteEngine ];
+		return [ BlockQuoteEditing, BlockQuoteUI ];
 	}
 
 	/**
@@ -36,58 +32,5 @@ export default class BlockQuote extends Plugin {
 	 */
 	static get pluginName() {
 		return 'BlockQuote';
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	init() {
-		const editor = this.editor;
-		const t = editor.t;
-		const command = editor.commands.get( 'blockQuote' );
-
-		editor.ui.componentFactory.add( 'blockQuote', locale => {
-			const buttonView = new ButtonView( locale );
-
-			buttonView.set( {
-				label: t( 'Block quote' ),
-				icon: quoteIcon,
-				tooltip: true
-			} );
-
-			// Bind button model to command.
-			buttonView.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
-
-			// Execute command.
-			this.listenTo( buttonView, 'execute', () => editor.execute( 'blockQuote' ) );
-
-			return buttonView;
-		} );
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	afterInit() {
-		const editor = this.editor;
-		const command = editor.commands.get( 'blockQuote' );
-
-		// Overwrite default Enter key behavior.
-		// If Enter key is pressed with selection collapsed in empty block inside a quote, break the quote.
-		// This listener is added in afterInit in order to register it after list's feature listener.
-		// We can't use a priority for this, because 'low' is already used by the enter feature, unless
-		// we'd use numeric priority in this case.
-		this.listenTo( this.editor.editing.view, 'enter', ( evt, data ) => {
-			const doc = this.editor.model.document;
-			const positionParent = doc.selection.getLastPosition().parent;
-
-			if ( doc.selection.isCollapsed && positionParent.isEmpty && command.value ) {
-				this.editor.execute( 'blockQuote' );
-				this.editor.editing.view.scrollToTheSelection();
-
-				data.preventDefault();
-				evt.stop();
-			}
-		} );
 	}
 }

--- a/src/blockquoteui.js
+++ b/src/blockquoteui.js
@@ -1,0 +1,50 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module block-quote/blockquoteui
+ */
+
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
+
+import quoteIcon from '@ckeditor/ckeditor5-core/theme/icons/quote.svg';
+import '../theme/blockquote.css';
+
+/**
+ * The block quote UI plugin.
+ *
+ * It introduces the `'blockQuote'` button.
+ *
+ * @extends module:core/plugin~Plugin
+ */
+export default class BlockQuoteUI extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+		const editor = this.editor;
+		const t = editor.t;
+
+		editor.ui.componentFactory.add( 'blockQuote', locale => {
+			const command = editor.commands.get( 'blockQuote' );
+			const buttonView = new ButtonView( locale );
+
+			buttonView.set( {
+				label: t( 'Block quote' ),
+				icon: quoteIcon,
+				tooltip: true
+			} );
+
+			// Bind button model to command.
+			buttonView.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
+
+			// Execute command.
+			this.listenTo( buttonView, 'execute', () => editor.execute( 'blockQuote' ) );
+
+			return buttonView;
+		} );
+	}
+}

--- a/tests/blockquote.js
+++ b/tests/blockquote.js
@@ -3,78 +3,12 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global document */
-
 import BlockQuote from '../src/blockquote';
-import BlockQuoteEngine from '../src/blockquoteengine';
-
-import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import BlockQuoteEditing from '../src/blockquoteediting';
+import BlockQuoteUI from '../src/blockquoteui';
 
 describe( 'BlockQuote', () => {
-	let editor, command, element;
-
-	beforeEach( () => {
-		element = document.createElement( 'div' );
-		document.body.appendChild( element );
-
-		return ClassicTestEditor
-			.create( element, {
-				plugins: [ BlockQuote ]
-			} )
-			.then( newEditor => {
-				editor = newEditor;
-				command = editor.commands.get( 'blockQuote' );
-			} );
-	} );
-
-	afterEach( () => {
-		element.remove();
-
-		return editor.destroy();
-	} );
-
-	it( 'requires BlockQuoteEngine', () => {
-		expect( BlockQuote.requires ).to.deep.equal( [ BlockQuoteEngine ] );
-	} );
-
-	describe( 'blockQuote button', () => {
-		it( 'has the base properties', () => {
-			const button = editor.ui.componentFactory.create( 'blockQuote' );
-
-			expect( button ).to.have.property( 'label', 'Block quote' );
-			expect( button ).to.have.property( 'icon' );
-			expect( button ).to.have.property( 'tooltip', true );
-		} );
-
-		it( 'has isOn bound to command\'s value', () => {
-			const button = editor.ui.componentFactory.create( 'blockQuote' );
-
-			command.value = false;
-			expect( button ).to.have.property( 'isOn', false );
-
-			command.value = true;
-			expect( button ).to.have.property( 'isOn', true );
-		} );
-
-		it( 'has isEnabled bound to command\'s isEnabled', () => {
-			const button = editor.ui.componentFactory.create( 'blockQuote' );
-
-			command.isEnabled = true;
-			expect( button ).to.have.property( 'isEnabled', true );
-
-			command.isEnabled = false;
-			expect( button ).to.have.property( 'isEnabled', false );
-		} );
-
-		it( 'executes command when it\'s executed', () => {
-			const button = editor.ui.componentFactory.create( 'blockQuote' );
-
-			const spy = sinon.stub( editor, 'execute' );
-
-			button.fire( 'execute' );
-
-			expect( spy.calledOnce ).to.be.true;
-			expect( spy.args[ 0 ][ 0 ] ).to.equal( 'blockQuote' );
-		} );
+	it( 'requires BlockQuoteEditing and BlockQuoteUI', () => {
+		expect( BlockQuote.requires ).to.deep.equal( [ BlockQuoteEditing, BlockQuoteUI ] );
 	} );
 } );

--- a/tests/blockquotecommand.js
+++ b/tests/blockquotecommand.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import BlockQuoteEngine from '../src/blockquoteengine';
+import BlockQuoteEditing from '../src/blockquoteediting';
 import BlockQuoteCommand from '../src/blockquotecommand';
 
 import { downcastElementToElement } from '@ckeditor/ckeditor5-engine/src/conversion/downcast-converters';
@@ -20,7 +20,7 @@ describe( 'BlockQuoteCommand', () => {
 	beforeEach( () => {
 		return VirtualTestEditor
 			.create( {
-				plugins: [ BlockQuoteEngine ]
+				plugins: [ BlockQuoteEditing ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;

--- a/tests/blockquoteediting.js
+++ b/tests/blockquoteediting.js
@@ -3,22 +3,22 @@
  * For licensing, see LICENSE.md.
  */
 
-import BlockQuoteEngine from '../src/blockquoteengine';
+import BlockQuoteEditing from '../src/blockquoteediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import ListEngine from '@ckeditor/ckeditor5-list/src/listengine';
+import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 import BlockQuoteCommand from '../src/blockquotecommand';
 
-describe( 'BlockQuoteEngine', () => {
+describe( 'BlockQuoteEditing', () => {
 	let editor, model;
 
 	beforeEach( () => {
 		return VirtualTestEditor
 			.create( {
-				plugins: [ BlockQuoteEngine, Paragraph ]
+				plugins: [ BlockQuoteEditing, Paragraph ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -69,7 +69,7 @@ describe( 'BlockQuoteEngine', () => {
 	it( 'allows list items inside blockQuote', () => {
 		return VirtualTestEditor
 			.create( {
-				plugins: [ BlockQuoteEngine, Paragraph, ListEngine ]
+				plugins: [ BlockQuoteEditing, Paragraph, ListEditing ]
 			} )
 			.then( editor => {
 				editor.setData( '<blockquote><ul><li>xx</li></ul></blockquote>' );

--- a/tests/blockquoteui.js
+++ b/tests/blockquoteui.js
@@ -1,0 +1,76 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* global document */
+
+import BlockQuoteEditing from '../src/blockquoteediting';
+import BlockQuoteUI from '../src/blockquoteui';
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+
+describe( 'BlockQuoteUI', () => {
+	let editor, command, element;
+
+	beforeEach( () => {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		return ClassicTestEditor
+			.create( element, {
+				plugins: [ BlockQuoteEditing, BlockQuoteUI ]
+			} )
+			.then( newEditor => {
+				editor = newEditor;
+				command = editor.commands.get( 'blockQuote' );
+			} );
+	} );
+
+	afterEach( () => {
+		element.remove();
+
+		return editor.destroy();
+	} );
+
+	describe( 'blockQuote button', () => {
+		it( 'has the base properties', () => {
+			const button = editor.ui.componentFactory.create( 'blockQuote' );
+
+			expect( button ).to.have.property( 'label', 'Block quote' );
+			expect( button ).to.have.property( 'icon' );
+			expect( button ).to.have.property( 'tooltip', true );
+		} );
+
+		it( 'has isOn bound to command\'s value', () => {
+			const button = editor.ui.componentFactory.create( 'blockQuote' );
+
+			command.value = false;
+			expect( button ).to.have.property( 'isOn', false );
+
+			command.value = true;
+			expect( button ).to.have.property( 'isOn', true );
+		} );
+
+		it( 'has isEnabled bound to command\'s isEnabled', () => {
+			const button = editor.ui.componentFactory.create( 'blockQuote' );
+
+			command.isEnabled = true;
+			expect( button ).to.have.property( 'isEnabled', true );
+
+			command.isEnabled = false;
+			expect( button ).to.have.property( 'isEnabled', false );
+		} );
+
+		it( 'executes command when it\'s executed', () => {
+			const button = editor.ui.componentFactory.create( 'blockQuote' );
+
+			const spy = sinon.stub( editor, 'execute' );
+
+			button.fire( 'execute' );
+
+			expect( spy.calledOnce ).to.be.true;
+			expect( spy.args[ 0 ][ 0 ] ).to.equal( 'blockQuote' );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Align feature class naming to a new scheme.

BREAKING CHANGE: Renamed `BlockQuoteEngine` to `BlockQuoteEditing`.
BREAKING CHANGE: Extracted `BlockQuoteUI` from `BlockQuote`.

---

### Additional information

* Part of feature split: https://github.com/ckeditor/ckeditor5/issues/488
