### PR TITLE
Enter will not break the quote if Shift is pressed

### DIFF
--- a/src/blockquoteediting.js
+++ b/src/blockquoteediting.js
@@ -50,8 +50,7 @@ export default class BlockQuoteEditing extends Plugin {
 		const command = editor.commands.get( 'blockQuote' );
 
 		// Overwrite default Enter key behavior.
-		// If Enter key is pressed with selection collapsed in empty block inside a quote, break the quote,
-		// unless the Shift key is pressed.
+		// If Enter key is pressed with selection collapsed in empty block inside a quote, break the quote.
 		// This listener is added in afterInit in order to register it after list's feature listener.
 		// We can't use a priority for this, because 'low' is already used by the enter feature, unless
 		// we'd use numeric priority in this case.
@@ -60,9 +59,6 @@ export default class BlockQuoteEditing extends Plugin {
 			const positionParent = doc.selection.getLastPosition().parent;
 
 			if ( doc.selection.isCollapsed && positionParent.isEmpty && command.value ) {
-				if ( data.domEvent && data.domEvent.shiftKey ) {
-					return;
-				}
 				this.editor.execute( 'blockQuote' );
 				this.editor.editing.view.scrollToTheSelection();
 

--- a/src/blockquoteediting.js
+++ b/src/blockquoteediting.js
@@ -50,7 +50,8 @@ export default class BlockQuoteEditing extends Plugin {
 		const command = editor.commands.get( 'blockQuote' );
 
 		// Overwrite default Enter key behavior.
-		// If Enter key is pressed with selection collapsed in empty block inside a quote, break the quote.
+		// If Enter key is pressed with selection collapsed in empty block inside a quote, break the quote,
+		// unless the Shift key is pressed.
 		// This listener is added in afterInit in order to register it after list's feature listener.
 		// We can't use a priority for this, because 'low' is already used by the enter feature, unless
 		// we'd use numeric priority in this case.
@@ -59,6 +60,9 @@ export default class BlockQuoteEditing extends Plugin {
 			const positionParent = doc.selection.getLastPosition().parent;
 
 			if ( doc.selection.isCollapsed && positionParent.isEmpty && command.value ) {
+				if ( data.domEvent && data.domEvent.shiftKey ) {
+					return;
+				}
 				this.editor.execute( 'blockQuote' );
 				this.editor.editing.view.scrollToTheSelection();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Enter with Shift will not break the quote. Closes #23 .

---

### Reason

Quote with empty lines is allowed by default:

![01](https://user-images.githubusercontent.com/24715727/39448454-8d37e252-4cf7-11e8-8e40-637473c00545.gif)

But I can't input an empty line in the quote directly because of that Enter key will break quote. So I add this future.

### Additional information

`DomEventData.domEvent` is an [undocumented](https://docs.ckeditor.com/ckeditor5/latest/api/module_engine_view_observer_domeventdata-DomEventData.html) attribute, which may cause some problem in future.
 