### PR TITLE
T/ckeditor5 table/126: BlockQuoteCommand should wrap only top-most blocks from selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@ckeditor/ckeditor5-image": "^11.0.0",
     "@ckeditor/ckeditor5-list": "^11.0.2",
     "@ckeditor/ckeditor5-paragraph": "^10.0.3",
+    "@ckeditor/ckeditor5-table": "^11.0.0",
     "@ckeditor/ckeditor5-typing": "^11.0.1",
     "eslint": "^5.5.0",
     "eslint-config-ckeditor5": "^1.0.7",

--- a/src/blockquotecommand.js
+++ b/src/blockquotecommand.js
@@ -34,7 +34,7 @@ export default class BlockQuoteCommand extends Command {
 	}
 
 	/**
-	 * Executes the command. When the command {@link #value is on}, all block quotes within
+	 * Executes the command. When the command {@link #value is on}, all top-most block quotes within
 	 * the selection will be removed. If it is off, all selected blocks will be wrapped with
 	 * a block quote.
 	 *
@@ -42,17 +42,10 @@ export default class BlockQuoteCommand extends Command {
 	 */
 	execute() {
 		const model = this.editor.model;
-		const doc = model.document;
 		const schema = model.schema;
+		const selection = model.document.selection;
 
-		const selectedBlocks = Array.from( doc.selection.getSelectedBlocks() );
-
-		const blocks = selectedBlocks.filter( block => {
-			const parentBlock = findAncestorBlock( model.createPositionBefore( block ), schema );
-
-			// Filter out blocks that are nested in other selected blocks (like paragraphs in tables).
-			return !parentBlock || !selectedBlocks.includes( parentBlock );
-		} );
+		const blocks = getTopMostBlocks( selection, schema );
 
 		model.change( writer => {
 			if ( this.value ) {
@@ -76,22 +69,11 @@ export default class BlockQuoteCommand extends Command {
 	 * @returns {Boolean} The current value.
 	 */
 	_getValue() {
-		const model = this.editor.model;
-		const schema = model.schema;
+		const schema = this.editor.model.schema;
+		const selection = this.editor.model.document.selection;
 
-		// TODO: Unify this with execute().
-		const selectedBlocks = Array.from( this.editor.model.document.selection.getSelectedBlocks() );
+		const firstBlock = getTopMostBlocks( selection, schema ).shift();
 
-		const blocks = selectedBlocks.filter( block => {
-			const parentBlock = findAncestorBlock( model.createPositionBefore( block ), schema );
-
-			// Filter out blocks that are nested in other selected blocks (like paragraphs in tables).
-			return !parentBlock || !selectedBlocks.includes( parentBlock );
-		} );
-
-		const firstBlock = blocks.shift();
-
-		// console.log( firstBlock );
 		// In the current implementation, the block quote must be an immediate parent of a block element.
 		return !!( firstBlock && findQuote( firstBlock ) );
 	}
@@ -246,8 +228,41 @@ function checkCanBeQuoted( schema, block ) {
 	return isBQAllowed && isBlockAllowedInBQ;
 }
 
-export function findAncestorBlock( position, schema ) {
-	let parent = position.parent;
+// Returns top-level block elements from selected blocks.
+//
+// For given selection:
+//
+//		[<blockA></blockA>
+//		<blockB>
+//			<blockC></blockC>
+//			<blockD></blockD>
+//		</blockB>
+//		<blockE></blockE>]
+//
+// This method will only return blocks: A, B & E.
+//
+// @param {module:engine/model/selection~Selection} selection
+// @param {module:engine/model/schema~Schema} schema
+// @returns {module:engine/model/element~Element[]}
+function getTopMostBlocks( selection, schema ) {
+	const topMostBlocks = Array.from( selection.getSelectedBlocks() )
+		.filter( block => {
+			const parentBlock = findAncestorBlock( block, schema );
+
+			// Filter out blocks that are nested in other selected blocks (like paragraphs in tables).
+			return !parentBlock || !Array.from( selection.getSelectedBlocks() ).includes( parentBlock );
+		} );
+
+	return topMostBlocks;
+}
+
+// Returns first ancestor block of a node.
+//
+// @param {module:engine/model/node~Node} node
+// @param {module:engine/model/schema~Schema} schema
+// @returns {module:engine/model/node~Node|undefined}
+function findAncestorBlock( node, schema ) {
+	let parent = node.parent;
 
 	while ( parent ) {
 		if ( schema.isBlock( parent ) ) {

--- a/src/blockquotecommand.js
+++ b/src/blockquotecommand.js
@@ -45,7 +45,7 @@ export default class BlockQuoteCommand extends Command {
 		const schema = model.schema;
 		const selection = model.document.selection;
 
-		const blocks = getTopMostBlocks( selection, schema );
+		const blocks = Array.from( selection.getTopMostBlocks() );
 
 		model.change( writer => {
 			if ( this.value ) {
@@ -69,10 +69,9 @@ export default class BlockQuoteCommand extends Command {
 	 * @returns {Boolean} The current value.
 	 */
 	_getValue() {
-		const schema = this.editor.model.schema;
 		const selection = this.editor.model.document.selection;
 
-		const firstBlock = getTopMostBlocks( selection, schema ).shift();
+		const firstBlock = first( selection.getTopMostBlocks() );
 
 		// In the current implementation, the block quote must be an immediate parent of a block element.
 		return !!( firstBlock && findQuote( firstBlock ) );
@@ -226,49 +225,4 @@ function checkCanBeQuoted( schema, block ) {
 	const isBlockAllowedInBQ = schema.checkChild( [ '$root', 'blockQuote' ], block );
 
 	return isBQAllowed && isBlockAllowedInBQ;
-}
-
-// Returns top-level block elements from selected blocks.
-//
-// For given selection:
-//
-//		[<blockA></blockA>
-//		<blockB>
-//			<blockC></blockC>
-//			<blockD></blockD>
-//		</blockB>
-//		<blockE></blockE>]
-//
-// This method will only return blocks: A, B & E.
-//
-// @param {module:engine/model/selection~Selection} selection
-// @param {module:engine/model/schema~Schema} schema
-// @returns {module:engine/model/element~Element[]}
-function getTopMostBlocks( selection, schema ) {
-	const topMostBlocks = Array.from( selection.getSelectedBlocks() )
-		.filter( block => {
-			const parentBlock = findAncestorBlock( block, schema );
-
-			// Filter out blocks that are nested in other selected blocks (like paragraphs in tables).
-			return !parentBlock || !Array.from( selection.getSelectedBlocks() ).includes( parentBlock );
-		} );
-
-	return topMostBlocks;
-}
-
-// Returns first ancestor block of a node.
-//
-// @param {module:engine/model/node~Node} node
-// @param {module:engine/model/schema~Schema} schema
-// @returns {module:engine/model/node~Node|undefined}
-function findAncestorBlock( node, schema ) {
-	let parent = node.parent;
-
-	while ( parent ) {
-		if ( schema.isBlock( parent ) ) {
-			return parent;
-		}
-
-		parent = parent.parent;
-	}
 }

--- a/src/blockquotecommand.js
+++ b/src/blockquotecommand.js
@@ -76,8 +76,22 @@ export default class BlockQuoteCommand extends Command {
 	 * @returns {Boolean} The current value.
 	 */
 	_getValue() {
-		const firstBlock = first( this.editor.model.document.selection.getSelectedBlocks() );
+		const model = this.editor.model;
+		const schema = model.schema;
 
+		// TODO: Unify this with execute().
+		const selectedBlocks = Array.from( this.editor.model.document.selection.getSelectedBlocks() );
+
+		const blocks = selectedBlocks.filter( block => {
+			const parentBlock = findAncestorBlock( model.createPositionBefore( block ), schema );
+
+			// Filter out blocks that are nested in other selected blocks (like paragraphs in tables).
+			return !parentBlock || !selectedBlocks.includes( parentBlock );
+		} );
+
+		const firstBlock = blocks.shift();
+
+		// console.log( firstBlock );
 		// In the current implementation, the block quote must be an immediate parent of a block element.
 		return !!( firstBlock && findQuote( firstBlock ) );
 	}

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -443,5 +443,28 @@ describe( 'BlockQuote integration', () => {
 				'[<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>]'
 			);
 		} );
+
+		it( 'wraps table cell paragraph', () => {
+			setModelData( model, '<table><tableRow><tableCell><paragraph>[]foo</paragraph></tableCell></tableRow></table>' );
+
+			editor.execute( 'blockQuote' );
+
+			expect( getModelData( model ) ).to.equal(
+				'<table><tableRow><tableCell><blockQuote><paragraph>[]foo</paragraph></blockQuote></tableCell></tableRow></table>'
+			);
+		} );
+
+		it( 'unwraps table cell paragraph', () => {
+			setModelData(
+				model,
+				'<table><tableRow><tableCell><blockQuote><paragraph>[]foo</paragraph></blockQuote></tableCell></tableRow></table>'
+			);
+
+			editor.execute( 'blockQuote' );
+
+			expect( getModelData( model ) ).to.equal(
+				'<table><tableRow><tableCell><paragraph>[]foo</paragraph></tableCell></tableRow></table>'
+			);
+		} );
 	} );
 } );

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -20,6 +20,7 @@ import {
 	getData as getModelData,
 	setData as setModelData
 } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import Table from '@ckeditor/ckeditor5-table/src/table';
 
 describe( 'BlockQuote integration', () => {
 	let editor, model, element, viewDocument;
@@ -30,7 +31,7 @@ describe( 'BlockQuote integration', () => {
 
 		return ClassicTestEditor
 			.create( element, {
-				plugins: [ BlockQuote, Paragraph, Image, ImageCaption, List, Enter, Delete, Heading ]
+				plugins: [ BlockQuote, Paragraph, Image, ImageCaption, List, Enter, Delete, Heading, Table ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -415,6 +416,20 @@ describe( 'BlockQuote integration', () => {
 				'<paragraph>xxx</paragraph>' +
 				'</blockQuote>' +
 				'<heading1>yyy[]o</heading1>'
+			);
+		} );
+	} );
+
+	describe( 'compatibility with tables', () => {
+		it( 'wraps whole table in paragraph', () => {
+			setModelData( model, '[<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>]' );
+
+			editor.execute( 'blockQuote' );
+
+			expect( getModelData( model ) ).to.equal(
+				'<blockQuote>' +
+				'[<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>]' +
+				'</blockQuote>'
 			);
 		} );
 	} );

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -421,15 +421,26 @@ describe( 'BlockQuote integration', () => {
 	} );
 
 	describe( 'compatibility with tables', () => {
-		it( 'wraps whole table in paragraph', () => {
+		it( 'wraps whole table', () => {
 			setModelData( model, '[<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>]' );
 
 			editor.execute( 'blockQuote' );
 
 			expect( getModelData( model ) ).to.equal(
-				'<blockQuote>' +
-				'[<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>]' +
-				'</blockQuote>'
+				'<blockQuote>[<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>]</blockQuote>'
+			);
+		} );
+
+		it( 'unwraps whole table', () => {
+			setModelData(
+				model,
+				'<blockQuote>[<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>]</blockQuote>'
+			);
+
+			editor.execute( 'blockQuote' );
+
+			expect( getModelData( model ) ).to.equal(
+				'[<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>]'
 			);
 		} );
 	} );

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -13,6 +13,7 @@ import List from '@ckeditor/ckeditor5-list/src/list';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import Delete from '@ckeditor/ckeditor5-typing/src/delete';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import Table from '@ckeditor/ckeditor5-table/src/table';
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import {
@@ -20,7 +21,6 @@ import {
 	getData as getModelData,
 	setData as setModelData
 } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import Table from '@ckeditor/ckeditor5-table/src/table';
 
 describe( 'BlockQuote integration', () => {
 	let editor, model, element, viewDocument;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Make BlockQuoteCommand wrap only top-most blocks.

---

### Additional information

* Requires changes in Table: https://github.com/ckeditor/ckeditor5-table/pull/153.
* Both repos updated for review in main repo: https://github.com/ckeditor/ckeditor5/tree/t/ckeditor5-table/126.

