### PR TITLE
Table selection handler should not be truncated inside a block quote.

### DIFF
--- a/theme/blockquote.css
+++ b/theme/blockquote.css
@@ -18,6 +18,6 @@
 
 .ck-content blockquote .table:first-child {
 	/* https://github.com/ckeditor/ckeditor5-block-quote/issues/28
-	`16px` = table selection handler height.*/
+	`16px` = table selection handler height. */
 	margin-top: calc(1em + 16px);
 }

--- a/theme/blockquote.css
+++ b/theme/blockquote.css
@@ -4,7 +4,7 @@
  */
 
 .ck-content blockquote {
-	/* See #12 */
+	/* https://github.com/ckeditor/ckeditor5-block-quote/issues/12 */
 	overflow: hidden;
 
 	/* https://github.com/ckeditor/ckeditor5-block-quote/issues/15 */
@@ -14,4 +14,10 @@
 	margin-left: 0;
 	font-style: italic;
 	border-left: solid 5px hsl(0, 0%, 80%);
+}
+
+.ck-content blockquote .table:first-child {
+	/* https://github.com/ckeditor/ckeditor5-block-quote/issues/28
+	`16px` = table selection handler height.*/
+	margin-top: calc(1em + 16px);
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Table selection handler should not be truncated inside a block quote. Closes: #28 

---

### Additional information

Because of no Edge support we can't use such CSS syntax:
```css
.ck-content blockquote .table:first-child {
  margin-top: calc( 1em + var(--ck-widget-handler-icon-size) );
}
```