### PR TITLE
Add possibility to force quoting or un-quoting in execute()

### DIFF
--- a/src/blockquotecommand.js
+++ b/src/blockquotecommand.js
@@ -39,6 +39,9 @@ export default class BlockQuoteCommand extends Command {
 	 * a block quote.
 	 *
 	 * @fires execute
+	 * @param {Object} [options] Command options.
+	 * @param {Boolean} [options.forceValue] If set, it will force the command behavior. If `true`, the command will apply a block quote,
+	 * otherwise the command will remove the block quote. If not set, the command will act basing on its current value.
 	 */
 	execute( options = {} ) {
 		const model = this.editor.model;

--- a/src/blockquotecommand.js
+++ b/src/blockquotecommand.js
@@ -40,15 +40,17 @@ export default class BlockQuoteCommand extends Command {
 	 *
 	 * @fires execute
 	 */
-	execute() {
+	execute( options = {} ) {
 		const model = this.editor.model;
 		const schema = model.schema;
 		const selection = model.document.selection;
 
 		const blocks = Array.from( selection.getTopMostBlocks() );
 
+		const value = ( options.forceValue === undefined ) ? !this.value : options.forceValue;
+
 		model.change( writer => {
-			if ( this.value ) {
+			if ( !value ) {
 				this._removeQuote( writer, blocks.filter( findQuote ) );
 			} else {
 				const blocksToQuote = blocks.filter( block => {
@@ -189,7 +191,7 @@ function findQuote( elementOrPosition ) {
 // Returns a minimal array of ranges containing groups of subsequent blocks.
 //
 // content:         abcdefgh
-// blocks:          [ a, b, d , f, g, h ]
+// blocks:          [ a, b, d, f, g, h ]
 // output ranges:   [ab]c[d]e[fgh]
 //
 // @param {Array.<module:engine/model/element~Element>} blocks

--- a/tests/blockquotecommand.js
+++ b/tests/blockquotecommand.js
@@ -438,6 +438,29 @@ describe( 'BlockQuoteCommand', () => {
 					'</blockQuote>'
 				);
 			} );
+
+			it( 'should handle forceValue = true param', () => {
+				setModelData(
+					model,
+					'<blockQuote>' +
+						'<paragraph>x[x</paragraph>' +
+					'</blockQuote>' +
+					'<paragraph>d]ef</paragraph>'
+				);
+
+				editor.execute( 'blockQuote', { forceValue: true } );
+
+				expect( getModelData( model ) ).to.equal(
+					'<blockQuote>' +
+						'<paragraph>x[x</paragraph>' +
+						'<paragraph>d]ef</paragraph>' +
+					'</blockQuote>'
+				);
+
+				expect( getViewData( editor.editing.view ) ).to.equal(
+					'<blockquote><p>x{x</p><p>d}ef</p></blockquote>'
+				);
+			} );
 		} );
 
 		describe( 'removing quote', () => {
@@ -596,6 +619,28 @@ describe( 'BlockQuoteCommand', () => {
 					'<p>yy</p>' +
 					'<p>de}f</p>' +
 					'<blockquote><p>ghi</p></blockquote>'
+				);
+			} );
+
+			it( 'should handle forceValue = false param', () => {
+				setModelData(
+					model,
+					'<paragraph>a[bc</paragraph>' +
+					'<blockQuote>' +
+						'<paragraph>x]x</paragraph>' +
+					'</blockQuote>'
+				);
+
+				editor.execute( 'blockQuote', { forceValue: false } );
+
+				// Incorrect selection.
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>a[bc]</paragraph>' +
+					'<paragraph>xx</paragraph>'
+				);
+
+				expect( getViewData( editor.editing.view ) ).to.equal(
+					'<p>a{bc}</p><p>xx</p>'
 				);
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Add possibility to force quoting or un-quoting in `execute()`. Closes: #35.