### PR TITLE
i/353: Focus the editor before executing a command

### DIFF
--- a/src/blockquoteui.js
+++ b/src/blockquoteui.js
@@ -43,7 +43,10 @@ export default class BlockQuoteUI extends Plugin {
 			buttonView.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
 
 			// Execute command.
-			this.listenTo( buttonView, 'execute', () => editor.execute( 'blockQuote' ) );
+			this.listenTo( buttonView, 'execute', () => {
+				editor.execute( 'blockQuote' );
+				editor.editing.view.focus();
+			} );
 
 			return buttonView;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Focus the editor before executing toolbar buttons' command. 

### Additonal information:
Master PR: https://github.com/ckeditor/ckeditor5/pull/6066

